### PR TITLE
MSDK-6335 - Improve processing session lifecycle documentation

### DIFF
--- a/IntegrationExample.xcodeproj/project.pbxproj
+++ b/IntegrationExample.xcodeproj/project.pbxproj
@@ -513,7 +513,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 5.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.mimi.IntegrationExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -551,7 +551,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 5.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.mimi.IntegrationExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -40,6 +40,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                 guard let self else { return }
 
                 switch state {
+                    // Activate processing when headphones are connected
                 case .connected(let model):
                     do {
                         let session = try activateMimiProcessing(techLevel: firmwareController.getTechLevel())
@@ -47,7 +48,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                     } catch {
                         fatalError("Failed to launch Mimi Processing:  \(error.localizedDescription)")
                     }
-                default:
+                case .disconnected:
+                    // Handle headphone disconnected state
+
                     return
                 }
             }

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -12,7 +12,7 @@ import MimiSDK
 import Combine
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
-    
+
     private let firmwareController: FirmwareControlling = PartnerFirmwareController()
     private let headphoneConnectivityController = PartnerHeadphoneConnectivityController()
     private var audioProcessingController: PartnerAudioProcessingController!
@@ -58,28 +58,28 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     // MARK: MimiSDK
-    
+
     private func startMimiCore() {
         // Set up
         Mimi.allowsUsageDataCollection = false
         MimiCore.shared.log.levels = [.all]
-        
+
         // Start SDK
         Mimi.start(credentials: .client(id: AppSecrets.mimiClientId, secret: AppSecrets.mimiClientSecret),
                    delegate: self)
-        
+
         // Set up headphone connectivity
         // For more documentation on this see: https://mimihearingtechnologies.github.io/SDKDocs-iOS/master/connected-headphone-identification.html
         MimiCore.shared.test.connectedHeadphoneProvider = headphoneConnectivityController
     }
-    
+
     private func activateMimiProcessing(techLevel: Int) throws -> MimiProcessingSession {
         let processing = MimiCore.shared.processing
-        
+
         // In the following, the session is instantiated with an UpDown datasource which provides (if available) a range of 3 presets - up, default & down. The UpDown datasource is the data source to be used for the so called Fine-tuning feature.
         let fitting = MimiPersonalization.Fitting.techLevel(techLevel)
         return try processing.activate(presetDataSource: .upDown(.init(fitting: fitting)))
-        
+
         // If only 1 preset, is desired, the Default datasource is to be used as follows.
 //        let fitting = MimiPersonalization.Fitting.techLevel(techLevel)
 //        return try processing.activate(presetDataSource: .default(.init(fitting: fitting)))
@@ -87,7 +87,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 }
 
 extension AppDelegate: MimiCoreDelegate {
-    
+
     func mimiCoreWasFoundUnserviceable(_ core: MimiCoreKit.MimiCore) {
         // Handle unserviceable Mimi core
     }

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -12,30 +12,30 @@ import MimiSDK
 import Combine
 
 final class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
-
+    
     private let firmwareController: FirmwareControlling = PartnerFirmwareController()
     private let headphoneConnectivityController = PartnerHeadphoneConnectivityController()
     private var audioProcessingController: PartnerAudioProcessingController!
-
+    
     private var cancellables = Set<AnyCancellable>()
-
+    
     // MARK: UIApplicationDelegate
-
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-
+        
         startMimiCore()
-
+        
         // Observe headphone connectivity state changes
         observeHeadphoneConnectivityState()
-
+        
         return true
     }
-
+    
     // Simulate a headphone connection, and as a result, activate the processing session
     func simulateHeadphoneConnection(isConnected: Bool) {
         headphoneConnectivityController.simulateHeadphoneConnection(isConnected: isConnected)
     }
-
+    
     private func observeHeadphoneConnectivityState() {
         headphoneConnectivityController.state
             .sink { state in
@@ -51,44 +51,44 @@ final class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
                 case .disconnected:
                     // Handle headphone disconnected state
                     MimiCore.shared.processing.deactivate()
-
+                    
                     return
                 }
             }
             .store(in: &cancellables)
     }
-
+    
     // MARK: MimiSDK
-
+    
     private func startMimiCore() {
         // Set up
         Mimi.allowsUsageDataCollection = false
         MimiCore.shared.log.levels = [.all]
-
+        
         // Start SDK
         Mimi.start(credentials: .client(id: AppSecrets.mimiClientId, secret: AppSecrets.mimiClientSecret),
                    delegate: self)
-
+        
         // Set up headphone connectivity
         // For more documentation on this see: https://mimihearingtechnologies.github.io/SDKDocs-iOS/master/connected-headphone-identification.html
         MimiCore.shared.test.connectedHeadphoneProvider = headphoneConnectivityController
     }
-
+    
     private func activateMimiProcessing(techLevel: Int) throws -> MimiProcessingSession {
         let processing = MimiCore.shared.processing
-
+        
         // In the following, the session is instantiated with an UpDown datasource which provides (if available) a range of 3 presets - up, default & down. The UpDown datasource is the data source to be used for the so called Fine-tuning feature.
         let fitting = MimiPersonalization.Fitting.techLevel(techLevel)
         return try processing.activate(presetDataSource: .upDown(.init(fitting: fitting)))
-
+        
         // If only 1 preset, is desired, the Default datasource is to be used as follows.
-//        let fitting = MimiPersonalization.Fitting.techLevel(techLevel)
-//        return try processing.activate(presetDataSource: .default(.init(fitting: fitting)))
+        //        let fitting = MimiPersonalization.Fitting.techLevel(techLevel)
+        //        return try processing.activate(presetDataSource: .default(.init(fitting: fitting)))
     }
 }
 
 extension AppDelegate: MimiCoreDelegate {
-
+    
     func mimiCoreWasFoundUnserviceable(_ core: MimiCoreKit.MimiCore) {
         // Handle unserviceable Mimi core
     }

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -13,7 +13,7 @@ import Combine
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
 
-    internal let headphoneConnectivityController = PartnerHeadphoneConnectivityController()
+    let headphoneConnectivityController = PartnerHeadphoneConnectivityController()
     private let firmwareController: FirmwareControlling = PartnerFirmwareController()
     private var audioProcessingController: PartnerAudioProcessingController!
 

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -14,7 +14,6 @@ import Combine
 final class AppDelegate: NSObject, UIApplicationDelegate {
 
     internal let headphoneConnectivityController = PartnerHeadphoneConnectivityController()
-
     private let firmwareController: FirmwareControlling = PartnerFirmwareController()
     private var audioProcessingController: PartnerAudioProcessingController!
 

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -11,14 +11,15 @@ import MimiUXKit
 import MimiSDK
 import Combine
 
-final class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
-    
+final class AppDelegate: NSObject, UIApplicationDelegate {
+
+    internal let headphoneConnectivityController = PartnerHeadphoneConnectivityController()
+
     private let firmwareController: FirmwareControlling = PartnerFirmwareController()
-    private let headphoneConnectivityController = PartnerHeadphoneConnectivityController()
     private var audioProcessingController: PartnerAudioProcessingController!
-    
+
     private var cancellables = Set<AnyCancellable>()
-    
+
     // MARK: UIApplicationDelegate
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
@@ -29,11 +30,6 @@ final class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
         observeHeadphoneConnectivityState()
         
         return true
-    }
-    
-    // Simulate a headphone connection, and as a result, activate the processing session
-    func simulateHeadphoneConnection(isConnected: Bool) {
-        headphoneConnectivityController.simulateHeadphoneConnection(isConnected: isConnected)
     }
     
     private func observeHeadphoneConnectivityState() {

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -34,7 +34,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     
     private func observeHeadphoneConnectivityState() {
         headphoneConnectivityController.state
-            .sink { state in
+            .sink { [weak self] state in
+                guard let self else { return }
+
                 switch state {
                     // Activate processing when headphones are connected
                 case .connected:

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -20,31 +20,31 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: UIApplicationDelegate
-    
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        
+
         startMimiCore()
 
         // Observe headphone connectivity state changes
         observeHeadphoneConnectivityState()
 
-        // Simulate headphone connection
-        headphoneConnectivityController.simulateHeadphoneConnection()
-
         return true
+    }
+
+    // Simulate a headphone connection, and as a result, activate the processing session
+    func simulateHeadphoneConnection() {
+        headphoneConnectivityController.simulateHeadphoneConnection()
     }
 
     private func observeHeadphoneConnectivityState() {
         headphoneConnectivityController.state
-            .sink { [weak self] state in
-                guard let self else { return }
-
+            .sink { state in
                 switch state {
                     // Activate processing when headphones are connected
-                case .connected(let model):
+                case .connected:
                     do {
-                        let session = try activateMimiProcessing(techLevel: firmwareController.getTechLevel())
-                        self.audioProcessingController = PartnerAudioProcessingController(session: session, firmwareController: firmwareController)
+                        let session = try self.activateMimiProcessing(techLevel: self.firmwareController.getTechLevel())
+                        self.audioProcessingController = PartnerAudioProcessingController(session: session, firmwareController: self.firmwareController)
                     } catch {
                         fatalError("Failed to launch Mimi Processing:  \(error.localizedDescription)")
                     }

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -82,8 +82,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
         return try processing.activate(presetDataSource: .upDown(.init(fitting: fitting)))
         
         // If only 1 preset, is desired, the Default datasource is to be used as follows.
-        //        let fitting = MimiPersonalization.Fitting.techLevel(techLevel)
-        //        return try processing.activate(presetDataSource: .default(.init(fitting: fitting)))
+//        let fitting = MimiPersonalization.Fitting.techLevel(techLevel)
+//        return try processing.activate(presetDataSource: .default(.init(fitting: fitting)))
     }
 }
 

--- a/IntegrationExample/AppDelegate.swift
+++ b/IntegrationExample/AppDelegate.swift
@@ -11,7 +11,7 @@ import MimiUXKit
 import MimiSDK
 import Combine
 
-final class AppDelegate: NSObject, UIApplicationDelegate {
+final class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
 
     private let firmwareController: FirmwareControlling = PartnerFirmwareController()
     private let headphoneConnectivityController = PartnerHeadphoneConnectivityController()
@@ -32,8 +32,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     // Simulate a headphone connection, and as a result, activate the processing session
-    func simulateHeadphoneConnection() {
-        headphoneConnectivityController.simulateHeadphoneConnection()
+    func simulateHeadphoneConnection(isConnected: Bool) {
+        headphoneConnectivityController.simulateHeadphoneConnection(isConnected: isConnected)
     }
 
     private func observeHeadphoneConnectivityState() {
@@ -50,6 +50,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                     }
                 case .disconnected:
                     // Handle headphone disconnected state
+                    MimiCore.shared.processing.deactivate()
 
                     return
                 }

--- a/IntegrationExample/ContentView.swift
+++ b/IntegrationExample/ContentView.swift
@@ -10,7 +10,6 @@ import MimiSDK
 import MimiCoreKit
 
 struct ContentView: View {
-    
     var body: some View {
         TabView {
             MimiProfileView(configuration: MimiProfileConfiguration())

--- a/IntegrationExample/ContentView.swift
+++ b/IntegrationExample/ContentView.swift
@@ -10,7 +10,7 @@ import MimiSDK
 import MimiCoreKit
 
 struct ContentView: View {
-
+    
     var body: some View {
         TabView {
             MimiProfileView(configuration: MimiProfileConfiguration())

--- a/IntegrationExample/ContentView.swift
+++ b/IntegrationExample/ContentView.swift
@@ -10,16 +10,25 @@ import MimiSDK
 import MimiCoreKit
 
 struct ContentView: View {
+
+    private var headphoneConnectivity: PartnerHeadphoneConnectivityController
+
+    init(headphoneConnectivity: PartnerHeadphoneConnectivityController) {
+        self.headphoneConnectivity = headphoneConnectivity
+    }
+
     var body: some View {
         TabView {
             MimiProfileView(configuration: MimiProfileConfiguration())
                 .tabItem {
                     Label("Profile", systemImage: "platter.2.filled.iphone")
                 }
-            
+
             Group {
                 if let session = MimiCore.shared.processing.session.value {
-                    ProcessingView(viewModel: ProcessingViewModel(session: session, authController: MimiCore.shared.auth))
+                    ProcessingView(viewModel: ProcessingViewModel(session: session,
+                                                                  authController: MimiCore.shared.auth,
+                                                                  headphoneConnectivity: headphoneConnectivity))
                 } else {
                     Text("Mimi Processing Session Unavailable")
                 }
@@ -27,7 +36,7 @@ struct ContentView: View {
             .tabItem {
                 Label("Processing", systemImage: "waveform")
             }
-            
+
             CoreView()
                 .tabItem {
                     Label("Core", systemImage: "wrench.and.screwdriver")
@@ -39,6 +48,6 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        ContentView(headphoneConnectivity: PartnerHeadphoneConnectivityController())
     }
 }

--- a/IntegrationExample/ContentView.swift
+++ b/IntegrationExample/ContentView.swift
@@ -10,6 +10,7 @@ import MimiSDK
 import MimiCoreKit
 
 struct ContentView: View {
+
     var body: some View {
         TabView {
             MimiProfileView(configuration: MimiProfileConfiguration())

--- a/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
+++ b/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
@@ -20,11 +20,7 @@ final class PartnerHeadphoneConnectivityController: MimiConnectedHeadphoneProvid
 
     private let model = "mimi-partner-headphone-model"
 
-    var state: CurrentValueSubject<ConnectivityState, Never>
-
-    init() {
-        state = CurrentValueSubject(.connected(model: model))
-    }
+    var state: CurrentValueSubject<ConnectivityState, Never> = CurrentValueSubject(.disconnected)
 
     func getMimiHeadphoneIdentifier() -> MimiHeadphoneIdentifier? {
         switch state.value {

--- a/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
+++ b/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
@@ -17,8 +17,14 @@ final class PartnerHeadphoneConnectivityController: MimiConnectedHeadphoneProvid
         case disconnected
         case connected(model: String)
     }
-    
-    var state: CurrentValueSubject<ConnectivityState, Never> = CurrentValueSubject(.disconnected)
+
+    private let model = "mimi-partner-headphone-model"
+
+    var state: CurrentValueSubject<ConnectivityState, Never>
+
+    init() {
+        state = CurrentValueSubject(.connected(model: model))
+    }
 
     func getMimiHeadphoneIdentifier() -> MimiHeadphoneIdentifier? {
         switch state.value {
@@ -31,10 +37,8 @@ final class PartnerHeadphoneConnectivityController: MimiConnectedHeadphoneProvid
         }
     }
 
-    /// Simulate headphone connection by setting the state to `connected` with mocked headphone model
-    func simulateHeadphoneConnection() {
-        let model = "mimi-partner-headphone-model"
-
-        state.send(.connected(model: model))
+    /// Simulate headphone connectivity state by setting the state to `connected` with mocked headphone model or `disconnected`
+    func simulateHeadphoneConnection(isConnected: Bool) {
+        state.send(isConnected ? .connected(model: model) : .disconnected )
     }
 }

--- a/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
+++ b/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
@@ -11,8 +11,8 @@ import Combine
 
 /// A mock headphone connectivity controller which simulates headphone connection and provides information on the currently connected headphone to the MSDK
 /// Documentation: https://mimihearingtechnologies.github.io/SDKDocs-iOS/master/connected-headphone-identification.html
-final class PartnerHeadphoneConnectivityController: MimiConnectedHeadphoneProvider {
-    
+final class PartnerHeadphoneConnectivityController: MimiConnectedHeadphoneProvider, ObservableObject {
+
     enum ConnectivityState {
         case disconnected
         case connected(model: String)

--- a/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
+++ b/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import MimiCoreKit
+import Combine
 
 /// A mock headphone connectivity controller which provides information on the currently connected headphone to the MSDK.
 /// Documentation: https://mimihearingtechnologies.github.io/SDKDocs-iOS/master/connected-headphone-identification.html
@@ -17,11 +18,10 @@ final class PartnerHeadphoneConnectivityController: MimiConnectedHeadphoneProvid
         case connected(model: String)
     }
     
-    var state: ConnectivityState = .connected(model: "mimi-partner-headphone-model") // Mock headphone model value.
-    
+    var state: CurrentValueSubject<ConnectivityState, Never> = CurrentValueSubject(.disconnected)
+
     func getMimiHeadphoneIdentifier() -> MimiHeadphoneIdentifier? {
-        
-        switch state {
+        switch state.value {
         case .disconnected:
             // Return nil if no headphone is currently connected.
             return nil
@@ -29,5 +29,12 @@ final class PartnerHeadphoneConnectivityController: MimiConnectedHeadphoneProvid
             // If headphone connected, return the headphone identifier based on the headphone model value.
             return MimiHeadphoneIdentifier(model: model)
         }
+    }
+
+    /// Simulate headphone connection by setting the state to `connected` with mocked headphone model
+    func simulateHeadphoneConnection() {
+        let model = "mimi-partner-headphone-model"
+
+        state.send(.connected(model: model))
     }
 }

--- a/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
+++ b/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
@@ -13,7 +13,7 @@ import Combine
 /// Documentation: https://mimihearingtechnologies.github.io/SDKDocs-iOS/master/connected-headphone-identification.html
 final class PartnerHeadphoneConnectivityController: MimiConnectedHeadphoneProvider, ObservableObject {
 
-    enum ConnectivityState {
+    enum ConnectivityState: Equatable {
         case disconnected
         case connected(model: String)
     }

--- a/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
+++ b/IntegrationExample/Core/PartnerHeadphoneConnectivityController.swift
@@ -9,7 +9,7 @@ import Foundation
 import MimiCoreKit
 import Combine
 
-/// A mock headphone connectivity controller which provides information on the currently connected headphone to the MSDK.
+/// A mock headphone connectivity controller which simulates headphone connection and provides information on the currently connected headphone to the MSDK
 /// Documentation: https://mimihearingtechnologies.github.io/SDKDocs-iOS/master/connected-headphone-identification.html
 final class PartnerHeadphoneConnectivityController: MimiConnectedHeadphoneProvider {
     

--- a/IntegrationExample/IntegrationExampleApp.swift
+++ b/IntegrationExample/IntegrationExampleApp.swift
@@ -12,10 +12,6 @@ struct IntegrationExampleApp: App {
     
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
-    init() {
-        appDelegate.simulateHeadphoneConnection()
-    }
-
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/IntegrationExample/IntegrationExampleApp.swift
+++ b/IntegrationExample/IntegrationExampleApp.swift
@@ -11,13 +11,14 @@ import SwiftUI
 struct IntegrationExampleApp: App {
     
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
+    init() {
+        appDelegate.simulateHeadphoneConnection()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .onAppear {
-                    appDelegate.simulateHeadphoneConnection()
-                }
         }
     }
 }

--- a/IntegrationExample/IntegrationExampleApp.swift
+++ b/IntegrationExample/IntegrationExampleApp.swift
@@ -15,6 +15,9 @@ struct IntegrationExampleApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onAppear {
+                    appDelegate.simulateHeadphoneConnection()
+                }
         }
     }
 }

--- a/IntegrationExample/IntegrationExampleApp.swift
+++ b/IntegrationExample/IntegrationExampleApp.swift
@@ -11,10 +11,11 @@ import SwiftUI
 struct IntegrationExampleApp: App {
     
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
     }
 }
+

--- a/IntegrationExample/IntegrationExampleApp.swift
+++ b/IntegrationExample/IntegrationExampleApp.swift
@@ -6,19 +6,21 @@
 //
 
 import SwiftUI
+import MimiCoreKit
 
 @main
 struct IntegrationExampleApp: App {
-    
+
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
     init() {
-        appDelegate.simulateHeadphoneConnection(isConnected: true)
+        appDelegate.headphoneConnectivityController.simulateHeadphoneConnection(isConnected: true)
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(appDelegate.headphoneConnectivityController)
         }
     }
 }

--- a/IntegrationExample/IntegrationExampleApp.swift
+++ b/IntegrationExample/IntegrationExampleApp.swift
@@ -19,8 +19,7 @@ struct IntegrationExampleApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environmentObject(appDelegate.headphoneConnectivityController)
+            ContentView(headphoneConnectivity: appDelegate.headphoneConnectivityController)
         }
     }
 }

--- a/IntegrationExample/IntegrationExampleApp.swift
+++ b/IntegrationExample/IntegrationExampleApp.swift
@@ -18,4 +18,3 @@ struct IntegrationExampleApp: App {
         }
     }
 }
-

--- a/IntegrationExample/IntegrationExampleApp.swift
+++ b/IntegrationExample/IntegrationExampleApp.swift
@@ -12,6 +12,10 @@ struct IntegrationExampleApp: App {
     
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
+    init() {
+        appDelegate.simulateHeadphoneConnection(isConnected: true)
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/IntegrationExample/Processing/View/ProcessingView.swift
+++ b/IntegrationExample/Processing/View/ProcessingView.swift
@@ -6,17 +6,45 @@
 //
 
 import SwiftUI
+import Combine
 import MimiCoreKit
 
 struct ProcessingView: View {
-    
+
+    @EnvironmentObject var appDelegate: AppDelegate
     @ObservedObject var viewModel: ProcessingViewModel
-    
+
+    @State var isHeadphoneConnected: Bool = true
+    @State private var cancellables = Set<AnyCancellable>()
+
     init(viewModel: ProcessingViewModel) {
         self.viewModel = viewModel
     }
-    
+
     var body: some View {
+        VStack(spacing: 64) {
+            connectivityView
+
+            parametersView
+                .opacity(isHeadphoneConnected ? 1 : 0)
+        }
+        .padding(.horizontal, 32)
+    }
+
+    private var connectivityView: some View {
+        VStack {
+            Text("Headphone Connectivity")
+                .font(.title2)
+            HStack {
+                Toggle("Headphones connected", isOn: Binding<Bool>(get: { isHeadphoneConnected }, set: { value in
+                    isHeadphoneConnected = value
+                    appDelegate.simulateHeadphoneConnection(isConnected: value)
+                }))
+            }
+        }
+    }
+
+    private var parametersView: some View {
         VStack(spacing: 32.0) {
             Text("Mimi Processing Parameters")
                 .font(.title2)
@@ -58,6 +86,5 @@ struct ProcessingView: View {
                 }
             }
         }
-        .padding(32.0)
     }
 }

--- a/IntegrationExample/Processing/View/ProcessingView.swift
+++ b/IntegrationExample/Processing/View/ProcessingView.swift
@@ -10,27 +10,27 @@ import Combine
 import MimiCoreKit
 
 struct ProcessingView: View {
-
+    
     @EnvironmentObject var appDelegate: AppDelegate
     @ObservedObject var viewModel: ProcessingViewModel
-
+    
     @State var isHeadphoneConnected: Bool = true
     @State private var cancellables = Set<AnyCancellable>()
-
+    
     init(viewModel: ProcessingViewModel) {
         self.viewModel = viewModel
     }
-
+    
     var body: some View {
         VStack(spacing: 64) {
             connectivityView
-
+            
             parametersView
                 .opacity(isHeadphoneConnected ? 1 : 0)
         }
         .padding(.horizontal, 32)
     }
-
+    
     private var connectivityView: some View {
         VStack {
             Text("Headphone Connectivity")
@@ -43,7 +43,7 @@ struct ProcessingView: View {
             }
         }
     }
-
+    
     private var parametersView: some View {
         VStack(spacing: 32.0) {
             Text("Mimi Processing Parameters")

--- a/IntegrationExample/Processing/View/ProcessingView.swift
+++ b/IntegrationExample/Processing/View/ProcessingView.swift
@@ -15,7 +15,6 @@ struct ProcessingView: View {
     @ObservedObject var viewModel: ProcessingViewModel
 
     @State var isHeadphoneConnected: Bool = true
-    @State private var cancellables = Set<AnyCancellable>()
     
     init(viewModel: ProcessingViewModel) {
         self.viewModel = viewModel

--- a/IntegrationExample/Processing/View/ProcessingView.swift
+++ b/IntegrationExample/Processing/View/ProcessingView.swift
@@ -11,9 +11,9 @@ import MimiCoreKit
 
 struct ProcessingView: View {
     
-    @EnvironmentObject var appDelegate: AppDelegate
+    @EnvironmentObject var headphoneConnectivity: PartnerHeadphoneConnectivityController
     @ObservedObject var viewModel: ProcessingViewModel
-    
+
     @State var isHeadphoneConnected: Bool = true
     @State private var cancellables = Set<AnyCancellable>()
     
@@ -38,7 +38,7 @@ struct ProcessingView: View {
             HStack {
                 Toggle("Headphones connected", isOn: Binding<Bool>(get: { isHeadphoneConnected }, set: { value in
                     isHeadphoneConnected = value
-                    appDelegate.simulateHeadphoneConnection(isConnected: value)
+                    headphoneConnectivity.simulateHeadphoneConnection(isConnected: value)
                 }))
             }
         }

--- a/IntegrationExample/Processing/View/ProcessingView.swift
+++ b/IntegrationExample/Processing/View/ProcessingView.swift
@@ -32,10 +32,9 @@ struct ProcessingView: View {
             Text("Headphone Connectivity")
                 .font(.title2)
             HStack {
-                Toggle("Headphones connected", isOn: Binding<Bool>(get: { viewModel.isHeadphoneConnected }, set: { value in
-                    viewModel.isHeadphoneConnected = value
-                    viewModel.headphoneConnectivity.simulateHeadphoneConnection(isConnected: value)
-                }))
+                Toggle("Headphones connected", 
+                       isOn: Binding<Bool>(get: { viewModel.isHeadphoneConnected},
+                                           set: { viewModel.simulateHeadphoneConnection(isConnected: $0) }))
             }
         }
     }

--- a/IntegrationExample/Processing/View/ProcessingView.swift
+++ b/IntegrationExample/Processing/View/ProcessingView.swift
@@ -10,11 +10,8 @@ import Combine
 import MimiCoreKit
 
 struct ProcessingView: View {
-    
-    @EnvironmentObject var headphoneConnectivity: PartnerHeadphoneConnectivityController
-    @ObservedObject var viewModel: ProcessingViewModel
 
-    @State var isHeadphoneConnected: Bool = true
+    @ObservedObject private var viewModel: ProcessingViewModel
     
     init(viewModel: ProcessingViewModel) {
         self.viewModel = viewModel
@@ -25,7 +22,7 @@ struct ProcessingView: View {
             connectivityView
             
             parametersView
-                .opacity(isHeadphoneConnected ? 1 : 0)
+                .opacity(viewModel.isHeadphoneConnected ? 1 : 0)
         }
         .padding(.horizontal, 32)
     }
@@ -35,9 +32,9 @@ struct ProcessingView: View {
             Text("Headphone Connectivity")
                 .font(.title2)
             HStack {
-                Toggle("Headphones connected", isOn: Binding<Bool>(get: { isHeadphoneConnected }, set: { value in
-                    isHeadphoneConnected = value
-                    headphoneConnectivity.simulateHeadphoneConnection(isConnected: value)
+                Toggle("Headphones connected", isOn: Binding<Bool>(get: { viewModel.isHeadphoneConnected }, set: { value in
+                    viewModel.isHeadphoneConnected = value
+                    viewModel.headphoneConnectivity.simulateHeadphoneConnection(isConnected: value)
                 }))
             }
         }

--- a/IntegrationExample/Processing/View/ProcessingViewModel.swift
+++ b/IntegrationExample/Processing/View/ProcessingViewModel.swift
@@ -13,7 +13,7 @@ import MimiCoreKit
 final class ProcessingViewModel: ObservableObject {
     
     var headphoneConnectivity: PartnerHeadphoneConnectivityController
-    @Published var isHeadphoneConnected: Bool = true
+    @Published var isHeadphoneConnected: Bool
 
     @Published var isEnabled: Bool
     @Published var intensity: Float
@@ -36,6 +36,7 @@ final class ProcessingViewModel: ObservableObject {
         self.intensity = session.intensity.value
         self.presetId = session.preset.value?.id
 
+        self.isHeadphoneConnected = headphoneConnectivity.state.value != .disconnected
         self.headphoneConnectivity = headphoneConnectivity
 
         self.isUserLoggedIn = authController.currentUser != nil

--- a/IntegrationExample/Processing/View/ProcessingViewModel.swift
+++ b/IntegrationExample/Processing/View/ProcessingViewModel.swift
@@ -12,7 +12,8 @@ import MimiCoreKit
 
 final class ProcessingViewModel: ObservableObject {
     
-    @ObservedObject var headphoneConnectivity: PartnerHeadphoneConnectivityController
+    var headphoneConnectivity: PartnerHeadphoneConnectivityController
+
     @Published var isHeadphoneConnected: Bool = true
 
     @Published var isEnabled: Bool

--- a/IntegrationExample/Processing/View/ProcessingViewModel.swift
+++ b/IntegrationExample/Processing/View/ProcessingViewModel.swift
@@ -11,8 +11,7 @@ import Combine
 import MimiCoreKit
 
 final class ProcessingViewModel: ObservableObject {
-    
-    var headphoneConnectivity: PartnerHeadphoneConnectivityController
+
     @Published var isHeadphoneConnected: Bool
 
     @Published var isEnabled: Bool
@@ -22,6 +21,7 @@ final class ProcessingViewModel: ObservableObject {
     @Published var isUserLoggedIn: Bool
     
     private let session: MimiProcessingSession
+    private let headphoneConnectivity: PartnerHeadphoneConnectivityController
     
     private var isEnabledApplyCancellable: AnyCancellable?
     private var intensityApplyCancellable: AnyCancellable?
@@ -50,6 +50,7 @@ final class ProcessingViewModel: ObservableObject {
         authController.observable.addObserver(self)
         
         subscribeToSessionParameterUpdates()
+        subscribeToHeadphoneConnectivityState()
     }
     
     private func subscribeToSessionParameterUpdates() {
@@ -68,6 +69,19 @@ final class ProcessingViewModel: ObservableObject {
         session.preset.$value
             .sink { [weak self] value in
                 self?.presetId = value?.id
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func subscribeToHeadphoneConnectivityState() {
+        headphoneConnectivity.state
+            .sink { [weak self] connectivityState in
+                switch connectivityState {
+                case .disconnected:
+                    self?.isHeadphoneConnected = false
+                case .connected:
+                    self?.isHeadphoneConnected = true
+                }
             }
             .store(in: &cancellables)
     }
@@ -110,6 +124,10 @@ final class ProcessingViewModel: ObservableObject {
             } receiveValue: { [weak self] preset in
                 self?.presetId = preset?.id
             }
+    }
+    
+    func simulateHeadphoneConnection(isConnected: Bool) {
+        headphoneConnectivity.simulateHeadphoneConnection(isConnected: isConnected)
     }
 }
 

--- a/IntegrationExample/Processing/View/ProcessingViewModel.swift
+++ b/IntegrationExample/Processing/View/ProcessingViewModel.swift
@@ -13,7 +13,6 @@ import MimiCoreKit
 final class ProcessingViewModel: ObservableObject {
     
     var headphoneConnectivity: PartnerHeadphoneConnectivityController
-
     @Published var isHeadphoneConnected: Bool = true
 
     @Published var isEnabled: Bool

--- a/IntegrationExample/Processing/View/ProcessingViewModel.swift
+++ b/IntegrationExample/Processing/View/ProcessingViewModel.swift
@@ -5,12 +5,16 @@
 //  Created by Hozefa Indorewala on 09.01.23.
 //
 
+import SwiftUI
 import Foundation
 import Combine
 import MimiCoreKit
 
 final class ProcessingViewModel: ObservableObject {
     
+    @EnvironmentObject var headphoneConnectivity: PartnerHeadphoneConnectivityController
+
+    @Published var isHeadphoneConnected: Bool = true
     @Published var isEnabled: Bool
     @Published var intensity: Float
     @Published var presetId: String?

--- a/IntegrationExample/Processing/View/ProcessingViewModel.swift
+++ b/IntegrationExample/Processing/View/ProcessingViewModel.swift
@@ -13,8 +13,8 @@ import MimiCoreKit
 final class ProcessingViewModel: ObservableObject {
     
     @EnvironmentObject var headphoneConnectivity: PartnerHeadphoneConnectivityController
-
     @Published var isHeadphoneConnected: Bool = true
+
     @Published var isEnabled: Bool
     @Published var intensity: Float
     @Published var presetId: String?

--- a/IntegrationExample/Processing/View/ProcessingViewModel.swift
+++ b/IntegrationExample/Processing/View/ProcessingViewModel.swift
@@ -35,6 +35,7 @@ final class ProcessingViewModel: ObservableObject {
         self.isEnabled = session.isEnabled.value
         self.intensity = session.intensity.value
         self.presetId = session.preset.value?.id
+
         self.headphoneConnectivity = headphoneConnectivity
 
         self.isUserLoggedIn = authController.currentUser != nil

--- a/IntegrationExample/Processing/View/ProcessingViewModel.swift
+++ b/IntegrationExample/Processing/View/ProcessingViewModel.swift
@@ -12,7 +12,7 @@ import MimiCoreKit
 
 final class ProcessingViewModel: ObservableObject {
     
-    @EnvironmentObject var headphoneConnectivity: PartnerHeadphoneConnectivityController
+    @ObservedObject var headphoneConnectivity: PartnerHeadphoneConnectivityController
     @Published var isHeadphoneConnected: Bool = true
 
     @Published var isEnabled: Bool
@@ -29,11 +29,14 @@ final class ProcessingViewModel: ObservableObject {
     
     private var cancellables = Set<AnyCancellable>()
     
-    init(session: MimiProcessingSession, authController: MimiAuthController) {
+    init(session: MimiProcessingSession, 
+         authController: MimiAuthController,
+         headphoneConnectivity: PartnerHeadphoneConnectivityController) {
         self.isEnabled = session.isEnabled.value
         self.intensity = session.intensity.value
         self.presetId = session.preset.value?.id
-        
+        self.headphoneConnectivity = headphoneConnectivity
+
         self.isUserLoggedIn = authController.currentUser != nil
         
         self.session = session


### PR DESCRIPTION
- Separates processing session activation from the app lifecycle 

Since we want to make it more clear that processing session lifecycle is not dependant on the app's lifecycle, this PR demonstrates that session should be handled based on headphone connectivity state.